### PR TITLE
修复静音判断错误

### DIFF
--- a/MX2_AudioPlayer/Src/Audio.c
+++ b/MX2_AudioPlayer/Src/Audio.c
@@ -44,7 +44,7 @@ __STATIC_INLINE void pcm_convert2(int16_t*, int16_t*);
 
 int8_t Audio_Play_Start(Audio_ID_t id)
 {
-  if (!USR.mute_flag) {
+  if (!USR.mute_flag && USR.config->Vol != 0) {
     DEBUG(4, "[Message] Put AudioID:%02x", id);
     while (osMessagePut(DAC_CMDHandle, id, osWaitForever) != osOK);
   }

--- a/MX2_AudioPlayer/Src/MainTask.c
+++ b/MX2_AudioPlayer/Src/MainTask.c
@@ -90,10 +90,11 @@ void StartDefaultTask(void const * argument)
   __ASM("BKPT 0");
   #endif
 
-  // 当配置音频音量为0时，默认与静音启动相同操作
-  if (USR.config->Vol == 0) {
-      USR.mute_flag = 1;
-  }
+  /**< 由于多Bank可能不同的Vol值，初始化时判断Vol为0不再是安全的操作 */
+  // // 当配置音频音量为0时，默认与静音启动相同操作
+  // if (USR.config->Vol == 0) {
+  //     USR.mute_flag = 1;
+  // }
 
   // 初始化结构体中的参数
   USR.sys_status = System_Restart;


### PR DESCRIPTION
# 问题描述
多Bank参数导致原有的静音标志可能造成错误的结果
# 解决办法
判断MuteFlag的同时加入音量是否等于0的判断