### PR TITLE
新的混合播放方式（误）

### DIFF
--- a/MX2_AudioPlayer/Src/USR_CONFIG.c
+++ b/MX2_AudioPlayer/Src/USR_CONFIG.c
@@ -13,7 +13,7 @@ const PARA_STATIC_t STATIC_USR = {
 
   .vol_warning = 2110,   //3.4v / 2 = 1.7v
   .vol_poweroff = 1923, //3.1v / 2
-  .vol_chargecomplete = 4096, //4.18v / 2
+  .vol_chargecomplete = 2594, //4.18v / 2
   .filelimits = {
     .bank_max = 3,
     .trigger_in_max = 10,


### PR DESCRIPTION
- 触发'Out'时可以通过Out_Delay设定延时时间，不设置时默认为200ms
- 音频在播放时有更好的音质