### PR TITLE
修复触发'In'不能正常播放音频的问题

### DIFF
--- a/MX2_AudioPlayer/Src/Audio.c
+++ b/MX2_AudioPlayer/Src/Audio.c
@@ -139,6 +139,8 @@ void Wav_Task(void const * argument)
 					Play_simple_wav(WAV_LOWPOWER);
 					break;
         case Audio_intoReady:
+          pri_now = PRI(NULL);
+          RESET_Buffer();
 					Play_IN_wav();
 					break;
         case Audio_BankSwitch:


### PR DESCRIPTION
- 在播放前将中断标志清零
- 在播放前将打开的音频文件都关闭

问题详见#14